### PR TITLE
Fix Info Bubble closing behavior via Context and improve SEO

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AdCampaignProvider, useAdCampaign } from './context/AdCampaignContext';
+import { EducationalModalProvider } from './context/EducationalModalContext';
 import MainLayout from './components/MainLayout';
 import CampaignStep from './components/CampaignStep';
 import AdSetStep from './components/AdSetStep';
@@ -31,12 +32,14 @@ const PreviewContent = () => {
 
 function App() {
   return (
-    <AdCampaignProvider>
-      <MainLayout
-        leftPanel={<StepContent />}
-        rightPanel={<PreviewContent />}
-      />
-    </AdCampaignProvider>
+    <EducationalModalProvider>
+      <AdCampaignProvider>
+        <MainLayout
+          leftPanel={<StepContent />}
+          rightPanel={<PreviewContent />}
+        />
+      </AdCampaignProvider>
+    </EducationalModalProvider>
   );
 }
 

--- a/src/components/InfoIcon.jsx
+++ b/src/components/InfoIcon.jsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Info } from 'lucide-react';
-import EducationalModal from './EducationalModal';
+import { useEducationalModal } from '../context/EducationalModalContext';
 import { educationalContent } from '../data/educationalContent';
-import { AnimatePresence } from 'framer-motion';
 
 const InfoIcon = ({ contentKey }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { openModal } = useEducationalModal();
   const data = educationalContent[contentKey];
 
   if (!data) return null;
@@ -13,31 +12,18 @@ const InfoIcon = ({ contentKey }) => {
   const handleOpen = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    setIsOpen(true);
+    openModal(contentKey);
   };
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={handleOpen}
-        className="inline-flex items-center justify-center text-blue-400 hover:text-blue-600 transition-colors ml-1.5 focus:outline-none cursor-pointer"
-        aria-label={`Learn more about ${data.title}`}
-      >
-        <Info size={16} />
-      </button>
-
-      <AnimatePresence>
-        {isOpen && (
-          <EducationalModal
-            key={`modal-${contentKey}`}
-            onClose={() => setIsOpen(false)}
-            title={data.title}
-            content={data.content}
-          />
-        )}
-      </AnimatePresence>
-    </>
+    <button
+      type="button"
+      onClick={handleOpen}
+      className="inline-flex items-center justify-center text-blue-400 hover:text-blue-600 transition-colors ml-1.5 focus:outline-none cursor-pointer"
+      aria-label={`Learn more about ${data.title}`}
+    >
+      <Info size={16} />
+    </button>
   );
 };
 

--- a/src/context/EducationalModalContext.jsx
+++ b/src/context/EducationalModalContext.jsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useState } from 'react';
+import EducationalModal from '../components/EducationalModal';
+import { educationalContent } from '../data/educationalContent';
+
+const EducationalModalContext = createContext();
+
+export const useEducationalModal = () => {
+  const context = useContext(EducationalModalContext);
+  if (!context) {
+    throw new Error('useEducationalModal must be used within an EducationalModalProvider');
+  }
+  return context;
+};
+
+export const EducationalModalProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentContent, setCurrentContent] = useState(null);
+
+  const openModal = (contentKey) => {
+    const data = educationalContent[contentKey];
+    if (data) {
+      setCurrentContent(data);
+      setIsOpen(true);
+    }
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    // Optional: Clear content after animation, but keeping it for now to avoid flicker during exit
+  };
+
+  return (
+    <EducationalModalContext.Provider value={{ openModal, closeModal }}>
+      {children}
+      {/*
+        Render the modal here.
+        Note: EducationalModal uses createPortal internally to mount to document.body,
+        so placement here just ensures it's part of the React tree.
+      */}
+      {isOpen && currentContent && (
+        <EducationalModal
+          onClose={closeModal}
+          title={currentContent.title}
+          content={currentContent.content}
+        />
+      )}
+    </EducationalModalContext.Provider>
+  );
+};


### PR DESCRIPTION
- Introduce `EducationalModalContext` to manage modal state globally, fixing the issue where closing the modal would cause it to immediately reopen due to event bubbling.
- Refactor `InfoIcon` to use the new context instead of local state.
- Refactor `CampaignStep.jsx`, `AdSetStep.jsx`, and `AdCreativeStep.jsx` to move `InfoIcon` components outside of `<label>` tags to fix HTML semantics and prevent label click propagation.
- Update `index.html` with relevant SEO meta tags (title, description, keywords, author, Open Graph, Twitter).